### PR TITLE
Handle redirect to route with params instead of only routeName

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,14 +31,14 @@ router.beforeEach((to, from, next) => {
 ```
 
 ## Usage
-Middlewares are simply ES6 exported functions. The function accepts a destructred object as parameter, which contains the store instance, a next function and a redirect function. **The redirect function accepts a route name as parameter.**
+Middlewares are simply ES6 exported functions. The function accepts a destructred object as parameter, which contains the store instance, a next function and a redirect function. **The redirect function accepts a route as parameter.**
 
 ```js
 //auth.js middleware file
 export default function auth ({ store, redirect, next }){
 
     if(!store.getters['user/id']){
-        return redirect('Login'); // 'Login' is the route name
+        return redirect({ name: 'Login' }); // You can pass a route object with parameters: `{ name: 'user', params: { id: userId } }`
     }
 
     //proceed the request

--- a/src/KernelHelper.js
+++ b/src/KernelHelper.js
@@ -2,13 +2,11 @@
  * Return a Vue route object (https://router.vuejs.org/api/#route-object-properties)
  * to tell the kernel which route to go
  *
- * @param routeName
- * @returns {{name: *}}
+ * @param route
+ * @returns route
  */
-export function redirect(routeName) {
-    return {
-        name: routeName
-    }
+export function redirect(route) {
+    return route
 }
 
 /**


### PR DESCRIPTION
Hello, thanks for your middleware system, it solves an issue I have on my own handler, but I faced the following: the `redirect` function only handle a route name when I need to handle a route with some params.

So I made these pull request. Tell me what you think about it.